### PR TITLE
[ADD] ESBEP-22481, fix cron job

### DIFF
--- a/account_financial_report_webkit/models/account_static_balance.py
+++ b/account_financial_report_webkit/models/account_static_balance.py
@@ -44,7 +44,8 @@ class AccountStaticBalance(models.Model):
             WHERE ap.state = 'done' and not ap.special {})
           SELECT period, account FROM balances WHERE balance IS NULL;
         """.format('AND ap.id IN %(period_ids)s' if periods else '')
-        self.env.cr.execute(query, {'period_ids': tuple(periods.ids)})
+        self.env.cr.execute(query, {
+            'period_ids': tuple(periods.ids) if periods else None})
         return self.env.cr.fetchall()
 
     @api.multi

--- a/account_financial_report_webkit/tests/test_account_static_balance.py
+++ b/account_financial_report_webkit/tests/test_account_static_balance.py
@@ -29,3 +29,7 @@ class TestAccountStaticBalance(SavepointCase):
                     'account_id': self.account.id,
                     'period_id': self.period.id
                 })
+
+    def test_run_cron(self):
+        """ The cron method runs without any errors """
+        self.env['account.static.balance'].auto_populate_table()


### PR DESCRIPTION
```
  File "/opt/odoo/parts/server-tools/cron_run_manually/ir_cron.py", line 72, in run_manually
    return method(*args)
  File "/opt/odoo/parts/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/parts/account-financial-reporting/account_financial_report_webkit/models/account_static_balance.py", line 66, in auto_populate_table
    periods, accounts = self.get_missing_periods_and_accounts()
  File "/opt/odoo/parts/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/parts/account-financial-reporting/account_financial_report_webkit/models/account_static_balance.py", line 77, in get_missing_periods_and_accounts
    missing_combinations = self.get_entries_to_calculate(periods=periods)
  File "/opt/odoo/parts/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/parts/account-financial-reporting/account_financial_report_webkit/models/account_static_balance.py", line 47, in get_entries_to_calculate
    self.env.cr.execute(query, {'period_ids': tuple(periods.ids)})
AttributeError: 'NoneType' object has no attribute 'ids
```