### PR TITLE
[FIX] UAASDEV-8477, don't call compute_init_balance on empty account list

### DIFF
--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -478,8 +478,9 @@ class CommonReportHeaderWebkit(common_report_header):
                     ('id', 'in', account_ids),
                     ('user_type.close_method', '=', 'none')
                 ])
-            self.update_account_data(res, self._compute_init_balance(
-                none_account_ids, pnl_periods_ids))
+            if none_account_ids:
+                self.update_account_data(res, self._compute_init_balance(
+                    none_account_ids, pnl_periods_ids))
 
         self.update_account_data(res, self._compute_init_balance(
             account_ids, bs_period_ids))


### PR DESCRIPTION
When exporting a report for a period range that does not include an opening
period, the initial balance will be requested from the static balance table.
For ledger accounts with report type 'none' this is done separately. Because
static balances do not accept an empty list of accounts, this breaks the
partner balance report because this report does not contain accounts with this
report type. Therefore, a check needs to be implemented if there are such
accounts amongst the accounts that are being reported on.