### PR TITLE
[FIX] Purge outdated balances, not up-to-date ones

### DIFF
--- a/account_financial_report_webkit/migrations/8.0.1.3.0/post-migration.py
+++ b/account_financial_report_webkit/migrations/8.0.1.3.0/post-migration.py
@@ -30,13 +30,13 @@ query = """
             SELECT
               -- Follow structure of account_static_balance
               1 AS create_uid,
-              NOW() AS create_date,
+              NOW() AT TIME ZONE 'UTC' + INTERVAL '1 SECOND' AS create_date,
               account_id AS account_id,
               sum(curr_balance) as curr_balance,
               1 AS write_uid,
               SUM(credit) AS credit,
               period_id AS period_id,
-              NOW() AS write_date,
+              NOW() AT TIME ZONE 'UTC' + INTERVAL '1 SECOND' AS write_date,
               SUM(debit) AS debit,
               sum(balance) as balance,
               journal_id AS journal_id

--- a/account_financial_report_webkit/models/account_static_balance.py
+++ b/account_financial_report_webkit/models/account_static_balance.py
@@ -86,8 +86,8 @@ class AccountStaticBalance(models.Model):
             WHERE EXISTS (SELECT * FROM account_journal_period ajp
                           WHERE ajp.period_id = asb.period_id
                           AND ajp.journal_id = asb.journal_id
-                          AND asb.create_date >= ajp.write_date
-                          OR ajp.state != 'done')
+                          AND (ajp.write_date >= asb.create_date
+                               OR ajp.state != 'done'))
         """)
         period_journal_map = self.get_missing_periods_accounts_and_journals()
         if not period_journal_map:
@@ -286,7 +286,7 @@ class AccountStaticBalance(models.Model):
                 SELECT * FROM account_journal_period ajp
                 WHERE ajp.period_id = asb.period_id
                     AND ajp.journal_id = asb.journal_id
-                    AND asb.create_date > ajp.write_date
+                    AND ajp.write_date < asb.create_date
                     AND ajp.state = 'done')
                 AND asb.period_id IN %(period_ids)s
             GROUP BY account_id


### PR DESCRIPTION
Also ensure that the migration balances for journal periods
created during the same migration are not selected for purging.